### PR TITLE
Add dev container config file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8080],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"christian-kohler.npm-intellisense"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION


This is a Dev Containers configuration file based on https://containers.dev/

This is the standard used by GitHub CodeSpaces. Adding this allows anyone to create a Code Space directly from the repository allowing them to edit in a browser (everyone gets 60 hours a month free). It also means any Dev Container compatible IDE can directly check the code out into an already configured development environment.

The setup of this container:

    It uses NodeJS 18. Although the Readme says 16, the files appeared to suggest you are using 18. If that is incorrect let me know and I can change it
    It forwards port 8080
    Auto installs the dependencies on container setup
    It installs a single VSCode extension. I don't do a lot of Node development, but that one showed as recommended. If there are other extensions that are useful the IDs just need to be added to the "extensions" block

Any questions or concerns around the setup let me know.
